### PR TITLE
Add filters to maestro_channels

### DIFF
--- a/.squad/agents/amos/history.md
+++ b/.squad/agents/amos/history.md
@@ -176,3 +176,9 @@ Per Holden's policy: pin exact versions, take HIGHER stable versions. Resolved c
 - `gh pr view 18` — mergeStateStatus: **CLEAN**, mergeable: **MERGEABLE** ✅
 
 **Outcome:** PR #18 is now conflict-free and ready to merge. All test infrastructure changes (Test.Sdk 18.5.1 + pinned xunit/NSubstitute versions) validated with latest dependency versions from team PRs.
+
+### 2026-05-22: Classification Cache-Isolation Test
+
+- Added `GetChannels_DifferentClassificationsUseIndependentCacheEntries` to verify null, `product`, and `infrastructure` channel classifications each get separate cache entries and cached results do not cross-contaminate.
+- NSubstitute pattern: configure distinct optional-argument calls with `_client.ListChannelsAsync(Arg.Any<CancellationToken>(), classification).Returns(...)`, then verify exact counts with `Received(1)` per classification; `Received.InOrder` is unnecessary for cache isolation because call count and result values are what matter.
+- Future cache-isolation tests should assert both the API invocation cardinality and a value-level discriminator in returned DTOs; cached SQLite round-trips may deserialize new instances, so avoid reference equality.

--- a/.squad/agents/naomi/history.md
+++ b/.squad/agents/naomi/history.md
@@ -17,6 +17,16 @@
 - `src/MaestroTool/Program.cs` — CLI commands
 - `src/MaestroTool.Tests/` — Unit tests (xUnit, NSubstitute)
 
+## Learnings
+
+### 2026-05-22: `maestro_channels` low-cost filtering
+
+- Chose optional `filter`, `classification`, and `compact` parameters on `maestro_channels`; no-arg calls keep the previous full bulleted markdown output.
+- `classification` flows to PCS `IChannels.ListChannelsAsync(classification, cancellationToken)` and gets its own cache key; `filter` is applied after the cached API result so name searches do not multiply API calls.
+- Kept `compact` as a bool instead of a format enum because the immediate need is a single low-token `name → id` text mode, not a broader output contract.
+- Deferred pagination: channels is small and hierarchical, and the prior audit found markdown tools do not fit `LimitedResults<T>` cleanly.
+- Live measurement on 168 channels: current full MCP-style markdown is 6,392 bytes; compact is 5,048 bytes (1,344 bytes / 21% saved). Filtering `.NET 10` reduces the list to 30 channels: 1,289 bytes full, 1,049 bytes compact.
+
 ## 2026-05-21: PR #20 — Parallelize subscription_health GitHub fan-out
 
 **PR:** https://github.com/lewing/maestro.mcp/pull/20  

--- a/.squad/decisions/inbox/naomi-channels-filter.md
+++ b/.squad/decisions/inbox/naomi-channels-filter.md
@@ -1,0 +1,23 @@
+# Decision: `maestro_channels` filter parameters
+
+**Author:** Naomi  
+**Date:** 2026-05-22  
+**Status:** Proposed / shipped for review
+
+## Context
+
+`maestro_channels` previously returned all channels as bulleted markdown. Most callers need a narrow name match or a classification-constrained list before using a channel ID.
+
+## Decision
+
+Add optional parameters to `maestro_channels`:
+
+- `filter`: case-insensitive substring match on channel name.
+- `classification`: passed through to PCS `IChannels.ListChannelsAsync(classification, cancellationToken)`.
+- `compact`: bool flag returning `name → id` lines instead of bulleted markdown.
+
+No-argument calls preserve the existing full bulleted list. `classification` gets a distinct cache entry; `filter` is applied after cache retrieval to avoid creating API/cache churn for ad hoc substring searches.
+
+## Deferred
+
+Do not add pagination. Channels is a small hierarchical dataset and previous review rejected forcing markdown tool output into `LimitedResults<T>`. Similar filter parameters for `default_channels` and `subscriptions` are deferred because those tools already have natural API filters and were outside this focused PR.

--- a/.squad/skills/mcp-tool-filtering/SKILL.md
+++ b/.squad/skills/mcp-tool-filtering/SKILL.md
@@ -1,0 +1,20 @@
+# MCP Tool Filtering
+
+Use this pattern when a read-only MCP tool lists a small-but-noisy dataset and callers usually need a subset.
+
+## Pattern
+
+1. Preserve no-argument behavior exactly for compatibility.
+2. Add optional, named parameters:
+   - `filter` for case-insensitive substring matching on the primary display name.
+   - Domain-native server-side filters (for example `classification`) when the underlying API already supports them.
+   - `compact` as a bool when the main low-token need is `name → id` text.
+3. Cache server-side filter results with distinct cache keys.
+4. Apply ad hoc substring filters after retrieving cached data so every search term does not create a new upstream API call.
+5. Update the `[Description]` on the tool and parameters so MCP hosts teach agents when to filter.
+6. Add tests at both service and MCP-tool layers: API pass-through, case-insensitive filtering, and compact formatting.
+
+## Avoid
+
+- Do not add pagination solely to markdown-returning tools when the dataset is small and callers mainly need discovery/filtering.
+- Do not introduce format enums until there are at least two durable alternate formats beyond the default.

--- a/src/MaestroTool.Core/Maestro/IMaestroApiClient.cs
+++ b/src/MaestroTool.Core/Maestro/IMaestroApiClient.cs
@@ -48,7 +48,7 @@ public interface IMaestroApiClient
 
     Task<Channel> GetChannelAsync(int id, CancellationToken cancellationToken = default);
 
-    Task<List<Channel>> ListChannelsAsync(CancellationToken cancellationToken = default);
+    Task<List<Channel>> ListChannelsAsync(CancellationToken cancellationToken = default, string? classification = null);
 
     Task<List<DefaultChannel>> ListDefaultChannelsAsync(
         string? repository = null,

--- a/src/MaestroTool.Core/Maestro/MaestroApiClient.cs
+++ b/src/MaestroTool.Core/Maestro/MaestroApiClient.cs
@@ -159,9 +159,9 @@ public class MaestroApiClient : IMaestroApiClient
         return _api.Channels.GetChannelAsync(id, cancellationToken);
     }
 
-    public Task<List<Channel>> ListChannelsAsync(CancellationToken cancellationToken = default)
+    public Task<List<Channel>> ListChannelsAsync(CancellationToken cancellationToken = default, string? classification = null)
     {
-        return _api.Channels.ListChannelsAsync(cancellationToken: cancellationToken);
+        return _api.Channels.ListChannelsAsync(classification: classification, cancellationToken: cancellationToken);
     }
 
     public Task<List<DefaultChannel>> ListDefaultChannelsAsync(

--- a/src/MaestroTool.Core/Maestro/MaestroService.cs
+++ b/src/MaestroTool.Core/Maestro/MaestroService.cs
@@ -80,12 +80,27 @@ public class MaestroService
             LongTtl); // Builds are immutable
     }
 
-    public Task<List<Channel>> GetChannelsAsync(bool noCache = false, CancellationToken cancellationToken = default)
+    public async Task<List<Channel>> GetChannelsAsync(
+        bool noCache = false,
+        CancellationToken cancellationToken = default,
+        string? classification = null,
+        string? filter = null)
     {
-        if (noCache) _cache.Invalidate("channels");
-        return _cache.GetOrAddAsync("channels",
-            () => _client.ListChannelsAsync(cancellationToken),
+        var normalizedClassification = string.IsNullOrWhiteSpace(classification) ? null : classification.Trim();
+        var key = normalizedClassification is null ? "channels" : $"channels:{normalizedClassification}";
+        if (noCache) _cache.Invalidate(key);
+
+        var channels = await _cache.GetOrAddAsync(key,
+            () => _client.ListChannelsAsync(cancellationToken, normalizedClassification),
             MediumTtl);
+
+        if (string.IsNullOrWhiteSpace(filter))
+            return channels;
+
+        var normalizedFilter = filter.Trim();
+        return channels
+            .Where(c => c.Name.Contains(normalizedFilter, StringComparison.OrdinalIgnoreCase))
+            .ToList();
     }
 
     public Task<Channel> GetChannelAsync(int id, bool noCache = false, CancellationToken cancellationToken = default)

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Channels.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Channels.cs
@@ -51,18 +51,26 @@ public partial class MaestroMcpTools
     }
 
     [McpServerTool(Name = "maestro_channels", Title = "List Channels", ReadOnly = true, Idempotent = true)]
-    [Description("List all Maestro channels.")]
+    [Description("List Maestro channels. Optional filter does a case-insensitive substring match on channel name (e.g. '.NET 10', 'VS 17.', 'Aspire'); classification is passed to Maestro; compact returns 'name → id' lines.")]
     public async Task<string> GetChannels(
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
+        [Description("Optional case-insensitive substring filter for channel names (e.g. '.NET 10', 'VS 17.', 'Aspire')")] string? filter = null,
+        [Description("Optional Maestro channel classification passed to the PCS API")]
+        string? classification = null,
+        [Description("Return compact 'name → id' lines instead of bulleted markdown")]
+        bool compact = false,
         CancellationToken cancellationToken = default)
     {
-        var channels = await _service.GetChannelsAsync(noCache, cancellationToken);
+        var channels = await _service.GetChannelsAsync(noCache, cancellationToken, classification, filter);
         var sb = new StringBuilder();
         sb.AppendLine($"Found {channels.Count} channel(s):\n");
 
         foreach (var ch in channels.OrderBy(c => c.Name))
         {
-            sb.AppendLine($"- **{ch.Name}** (ID: {ch.Id})");
+            if (compact)
+                sb.AppendLine($"{ch.Name} → {ch.Id}");
+            else
+                sb.AppendLine($"- **{ch.Name}** (ID: {ch.Id})");
         }
 
         return Timestamp(noCache) + sb.ToString();

--- a/src/MaestroTool.Tests/Maestro/MaestroServiceTests.cs
+++ b/src/MaestroTool.Tests/Maestro/MaestroServiceTests.cs
@@ -434,6 +434,39 @@ public class MaestroServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetChannels_DifferentClassificationsUseIndependentCacheEntries()
+    {
+        var unclassifiedChannels = new List<Channel> { new(1, "All Channels", null) };
+        var productChannels = new List<Channel> { new(2, "Product Channels", "product") };
+        var infrastructureChannels = new List<Channel> { new(3, "Infrastructure Channels", "infrastructure") };
+
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>(), null)
+            .Returns(unclassifiedChannels);
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>(), "product")
+            .Returns(productChannels);
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>(), "infrastructure")
+            .Returns(infrastructureChannels);
+
+        var unclassifiedFirst = await _service.GetChannelsAsync(classification: null);
+        var productFirst = await _service.GetChannelsAsync(classification: "product");
+        var infrastructureFirst = await _service.GetChannelsAsync(classification: "infrastructure");
+        var unclassifiedSecond = await _service.GetChannelsAsync(classification: null);
+        var productSecond = await _service.GetChannelsAsync(classification: "product");
+        var infrastructureSecond = await _service.GetChannelsAsync(classification: "infrastructure");
+
+        Assert.Equal([1], unclassifiedFirst.Select(c => c.Id));
+        Assert.Equal([2], productFirst.Select(c => c.Id));
+        Assert.Equal([3], infrastructureFirst.Select(c => c.Id));
+        Assert.Equal([1], unclassifiedSecond.Select(c => c.Id));
+        Assert.Equal([2], productSecond.Select(c => c.Id));
+        Assert.Equal([3], infrastructureSecond.Select(c => c.Id));
+        await _client.Received(1).ListChannelsAsync(Arg.Any<CancellationToken>(), null);
+        await _client.Received(1).ListChannelsAsync(Arg.Any<CancellationToken>(), "product");
+        await _client.Received(1).ListChannelsAsync(Arg.Any<CancellationToken>(), "infrastructure");
+        await _client.Received(3).ListChannelsAsync(Arg.Any<CancellationToken>(), Arg.Any<string?>());
+    }
+
+    [Fact]
     public async Task GetChannels_WithFilter_FiltersByNameCaseInsensitive()
     {
         var channels = new List<Channel>

--- a/src/MaestroTool.Tests/Maestro/MaestroServiceTests.cs
+++ b/src/MaestroTool.Tests/Maestro/MaestroServiceTests.cs
@@ -421,6 +421,37 @@ public class MaestroServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetChannels_WithClassification_PassesThroughToApi()
+    {
+        var channels = new List<Channel> { CreateChannel(1, ".NET 10") };
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>(), "product")
+            .Returns(channels);
+
+        var result = await _service.GetChannelsAsync(classification: "product");
+
+        Assert.Single(result);
+        await _client.Received(1).ListChannelsAsync(Arg.Any<CancellationToken>(), "product");
+    }
+
+    [Fact]
+    public async Task GetChannels_WithFilter_FiltersByNameCaseInsensitive()
+    {
+        var channels = new List<Channel>
+        {
+            CreateChannel(1, ".NET 10.0.1xx SDK"),
+            CreateChannel(2, ".NET 9.0.1xx SDK"),
+            CreateChannel(3, "VS 17.14")
+        };
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>())
+            .Returns(channels);
+
+        var result = await _service.GetChannelsAsync(filter: "net 10");
+
+        var channel = Assert.Single(result);
+        Assert.Equal(1, channel.Id);
+    }
+
+    [Fact]
     public async Task GetChannelByName_FindsMatchingChannel()
     {
         var channels = new List<Channel>

--- a/src/MaestroTool.Tests/MaestroMcpTools/MaestroMcpToolsTests.cs
+++ b/src/MaestroTool.Tests/MaestroMcpTools/MaestroMcpToolsTests.cs
@@ -196,6 +196,56 @@ public class MaestroMcpToolsTests : IDisposable
         Assert.Contains("invalid", result, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task GetChannels_WithFilter_ReturnsOnlyMatchingChannels()
+    {
+        var channels = new List<Channel>
+        {
+            CreateChannel(id: 1, name: ".NET 10.0.1xx SDK"),
+            CreateChannel(id: 2, name: ".NET 9.0.1xx SDK"),
+            CreateChannel(id: 3, name: "VS 17.14")
+        };
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>())
+            .Returns(channels);
+
+        var result = await _tools.GetChannels(filter: "net 10");
+
+        Assert.Contains(".NET 10.0.1xx SDK", result);
+        Assert.DoesNotContain(".NET 9.0.1xx SDK", result);
+        Assert.DoesNotContain("VS 17.14", result);
+    }
+
+    [Fact]
+    public async Task GetChannels_WithClassification_PassesThroughToService()
+    {
+        var channels = new List<Channel> { CreateChannel(id: 1, name: ".NET 10.0.1xx SDK") };
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>(), "product")
+            .Returns(channels);
+
+        var result = await _tools.GetChannels(classification: "product");
+
+        Assert.Contains(".NET 10.0.1xx SDK", result);
+        await _client.Received(1).ListChannelsAsync(Arg.Any<CancellationToken>(), "product");
+    }
+
+    [Fact]
+    public async Task GetChannels_WithCompact_ReturnsNameToIdLines()
+    {
+        var channels = new List<Channel>
+        {
+            CreateChannel(id: 10, name: ".NET 10.0.1xx SDK"),
+            CreateChannel(id: 20, name: "VS 17.14")
+        };
+        _client.ListChannelsAsync(Arg.Any<CancellationToken>())
+            .Returns(channels);
+
+        var result = await _tools.GetChannels(compact: true);
+
+        Assert.Contains(".NET 10.0.1xx SDK → 10", result);
+        Assert.Contains("VS 17.14 → 20", result);
+        Assert.DoesNotContain("- **", result);
+    }
+
     // ================================================================
     // Smart trigger_subscription - auto-resolve latest build
     // ================================================================


### PR DESCRIPTION
## Summary
- add optional filter, classification, and compact parameters to maestro_channels
- pass classification through to PCS and cache classified channel lists separately
- keep no-argument output unchanged; add service/tool tests and squad documentation

## Verification
- dotnet build --nologo --verbosity minimal
- dotnet test --nologo --verbosity minimal (184/184 passed)

## Notes
- pagination intentionally deferred for channels per prior audit; filtering plus compact output addresses the context-size issue with lower complexity