### PR TITLE
Add filters to maestro_subscription_health

### DIFF
--- a/.squad/agents/naomi/history.md
+++ b/.squad/agents/naomi/history.md
@@ -19,6 +19,12 @@
 
 ## Learnings
 
+### 2026-05-22: PR #23 reviewer fixes — error-state filtering and AzDO short names
+
+- `staleOnly`/"show broken" filters must include unknown or errored health states, not just explicit stale booleans; silently omitting error rows hides the highest-risk cases.
+- Compact health output should avoid mixed signals: errored rows render as `error`, not `current`, even when `IsStale` is false.
+- AzDO repository display/filter short names should reuse `MaestroService.ParseAzDoUrl`; `dev.azure.com/{org}/{project}/_git/{repo}` and legacy Visual Studio URLs parse to `(org, project, repo)`, which can be rendered consistently as `org/project/repo`.
+
 ### 2026-05-22: `maestro_subscription_health` stale filters and compact mode
 
 - Added opt-in MCP parameters `staleOnly`, `channelFilter`, `sourceRepoFilter`, and `compact`; no-arg output remains the same detailed per-subscription block.

--- a/.squad/agents/naomi/history.md
+++ b/.squad/agents/naomi/history.md
@@ -19,6 +19,15 @@
 
 ## Learnings
 
+### 2026-05-22: `maestro_subscription_health` stale filters and compact mode
+
+- Added opt-in MCP parameters `staleOnly`, `channelFilter`, `sourceRepoFilter`, and `compact`; no-arg output remains the same detailed per-subscription block.
+- Names are domain-specific rather than a generic `filter` because subscription health has two natural axes: channel and source repo; `staleOnly` matches the common "what is broken" workflow.
+- Filters apply after `GetSubscriptionHealthAsync` completes its parallel fan-out, preserving PR #20's concurrency and avoiding new cache/API-key dimensions for ad hoc substring searches.
+- Extracted formatter helpers so tests can target filtering and markdown rendering directly without PCS network calls.
+- Compact lines intentionally omit channel names and shorten PR URLs to `#N` to keep scanning dense: `⚠️ dotnet/runtime → main: 42 commits behind (PR: #123)`.
+- Live dotnet/dotnet measurement from local tool harness: detailed formatter 24,398 bytes for 93 subscriptions / 43 stale; `staleOnly + compact` 3,049 bytes (~87.5% smaller).
+
 ### 2026-05-22: `maestro_channels` low-cost filtering
 
 - Chose optional `filter`, `classification`, and `compact` parameters on `maestro_channels`; no-arg calls keep the previous full bulleted markdown output.

--- a/.squad/decisions/inbox/naomi-subscription-health-filters.md
+++ b/.squad/decisions/inbox/naomi-subscription-health-filters.md
@@ -1,0 +1,26 @@
+# Subscription Health Filtering and Compact Output
+
+**Author:** Naomi  
+**Date:** 2026-05-22  
+**Status:** Proposed
+
+## Decision
+
+Add opt-in filtering and compact rendering directly to the `maestro_subscription_health` MCP tool:
+
+- `staleOnly` omits healthy subscriptions.
+- `channelFilter` matches channel names case-insensitively.
+- `sourceRepoFilter` matches source repository URLs or short repo names case-insensitively.
+- `compact` renders one line per subscription for low-token scanning.
+
+## Rationale
+
+`maestro_subscription_health` is expensive because it fans out across every active subscription and can produce very large markdown output. PR #20 already fixed wall-clock latency with parallel fan-out; this decision preserves that by applying filters only after health results are computed. The main user workflow is finding broken subscriptions, so `staleOnly + compact` should be the default recommendation for broad repo health triage.
+
+## Compatibility
+
+All knobs are optional. Existing no-argument callers keep the detailed markdown output unchanged.
+
+## Measurement
+
+For live `https://github.com/dotnet/dotnet` data, the detailed formatter produced 24,398 bytes for 93 subscriptions / 43 stale. `staleOnly + compact` produced 3,049 bytes, about an 87.5% reduction.

--- a/.squad/skills/mcp-tool-filtering/SKILL.md
+++ b/.squad/skills/mcp-tool-filtering/SKILL.md
@@ -1,6 +1,13 @@
 # MCP Tool Filtering
 
+Confidence: high
+
 Use this pattern when a read-only MCP tool lists a small-but-noisy dataset and callers usually need a subset.
+
+## Examples
+
+- `maestro_channels`: `filter`, server-side `classification`, and `compact` name/id lines.
+- `maestro_subscription_health`: `staleOnly`, `channelFilter`, `sourceRepoFilter`, and `compact` one-line health summaries.
 
 ## Pattern
 

--- a/.squad/skills/mcp-tool-filtering/SKILL.md
+++ b/.squad/skills/mcp-tool-filtering/SKILL.md
@@ -20,6 +20,7 @@ Use this pattern when a read-only MCP tool lists a small-but-noisy dataset and c
 4. Apply ad hoc substring filters after retrieving cached data so every search term does not create a new upstream API call.
 5. Update the `[Description]` on the tool and parameters so MCP hosts teach agents when to filter.
 6. Add tests at both service and MCP-tool layers: API pass-through, case-insensitive filtering, and compact formatting.
+7. For "show broken" filters (for example `staleOnly`), include errored/unknown states as non-healthy unless the parameter explicitly says otherwise.
 
 ## Avoid
 

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Subscriptions.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Subscriptions.cs
@@ -97,13 +97,13 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_subscription_health", Title = "Subscription Health", ReadOnly = true, Idempotent = true)]
-    [Description("Check subscription health for a target repository. Optional staleOnly omits healthy subscriptions; channelFilter and sourceRepoFilter do case-insensitive substring matching after cached health checks; compact returns one line per subscription.")]
+    [Description("Check subscription health for a target repository. Optional staleOnly includes stale or errored subscriptions; channelFilter and sourceRepoFilter do case-insensitive substring matching after cached health checks; compact returns one line per subscription.")]
     public async Task<string> GetSubscriptionHealth(
         [Description("Target repository URL (e.g. https://github.com/dotnet/dotnet)")] string targetRepository,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
         [Description("Include recent commit details (SHA, message, author, date) for stale subscriptions")] bool includeCommitDetails = false,
         [Description("Cross-validate stale subscriptions against GitHub ground truth (PR activity, commit reachability). Slower but detects stuck bookkeeping.")] bool validate = false,
-        [Description("Only show stale subscriptions; healthy subscriptions are omitted from output")] bool staleOnly = false,
+        [Description("Only show stale or errored subscriptions; healthy subscriptions are omitted from output")] bool staleOnly = false,
         [Description("Optional case-insensitive substring filter on channel name")] string? channelFilter = null,
         [Description("Optional case-insensitive substring filter on source repository URL or short name (e.g. dotnet/runtime or runtime)")] string? sourceRepoFilter = null,
         [Description("Return one line per subscription instead of the detailed multi-line block")] bool compact = false,
@@ -127,7 +127,7 @@ public partial class MaestroMcpTools
         var filtered = results;
 
         if (staleOnly)
-            filtered = filtered.Where(r => r.IsStale);
+            filtered = filtered.Where(r => r.IsStale || r.Error != null);
 
         if (!string.IsNullOrWhiteSpace(channelFilter))
         {
@@ -262,9 +262,11 @@ public partial class MaestroMcpTools
     private static string FormatCompactSubscriptionHealthLine(SubscriptionHealthResult result)
     {
         var source = ShortRepositoryName(result.SourceRepository);
-        var status = result.IsStale
-            ? FormatCompactStaleStatus(result)
-            : "current";
+        var status = result.Error != null
+            ? "error"
+            : result.IsStale
+                ? FormatCompactStaleStatus(result)
+                : "current";
         var pr = CompactPrReference(result.TrackedPr?.PrUrl);
         var prefix = result.Error != null ? "❌" : result.IsStale ? "⚠️" : "✅";
         var error = result.Error != null ? $"; error: {result.Error}" : "";
@@ -290,8 +292,14 @@ public partial class MaestroMcpTools
         return $"~{result.BuildsBehind} builds behind";
     }
 
-    private static string ShortRepositoryName(string repository)
+    internal static string ShortRepositoryName(string repository)
     {
+        var parsedAzDoUrl = MaestroService.ParseAzDoUrl(repository);
+        if (parsedAzDoUrl is { } azdo)
+        {
+            return $"{azdo.org}/{azdo.project}/{azdo.repo}";
+        }
+
         var trimmed = repository.Trim().TrimEnd('/');
         if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
         {

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Subscriptions.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Subscriptions.cs
@@ -97,12 +97,16 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_subscription_health", Title = "Subscription Health", ReadOnly = true, Idempotent = true)]
-    [Description("Check subscription health for a target repository. For each active subscription, compares the last applied build against the latest available build on the channel to detect stale subscriptions. Start here for most investigations. For listing/filtering subscriptions, use maestro_subscriptions.")]
+    [Description("Check subscription health for a target repository. Optional staleOnly omits healthy subscriptions; channelFilter and sourceRepoFilter do case-insensitive substring matching after cached health checks; compact returns one line per subscription.")]
     public async Task<string> GetSubscriptionHealth(
         [Description("Target repository URL (e.g. https://github.com/dotnet/dotnet)")] string targetRepository,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
         [Description("Include recent commit details (SHA, message, author, date) for stale subscriptions")] bool includeCommitDetails = false,
         [Description("Cross-validate stale subscriptions against GitHub ground truth (PR activity, commit reachability). Slower but detects stuck bookkeeping.")] bool validate = false,
+        [Description("Only show stale subscriptions; healthy subscriptions are omitted from output")] bool staleOnly = false,
+        [Description("Optional case-insensitive substring filter on channel name")] string? channelFilter = null,
+        [Description("Optional case-insensitive substring filter on source repository URL or short name (e.g. dotnet/runtime or runtime)")] string? sourceRepoFilter = null,
+        [Description("Return one line per subscription instead of the detailed multi-line block")] bool compact = false,
         CancellationToken cancellationToken = default)
     {
         var results = await _service.GetSubscriptionHealthAsync(targetRepository, noCache, includeCommitDetails, validate, cancellationToken);
@@ -110,12 +114,50 @@ public partial class MaestroMcpTools
         if (results.Count == 0)
             return $"No active subscriptions found targeting {targetRepository}.";
 
+        var filteredResults = FilterSubscriptionHealthResults(results, staleOnly, channelFilter, sourceRepoFilter).ToList();
+        return Timestamp(noCache) + FormatSubscriptionHealth(targetRepository, filteredResults, compact);
+    }
+
+    internal static IEnumerable<SubscriptionHealthResult> FilterSubscriptionHealthResults(
+        IEnumerable<SubscriptionHealthResult> results,
+        bool staleOnly = false,
+        string? channelFilter = null,
+        string? sourceRepoFilter = null)
+    {
+        var filtered = results;
+
+        if (staleOnly)
+            filtered = filtered.Where(r => r.IsStale);
+
+        if (!string.IsNullOrWhiteSpace(channelFilter))
+        {
+            filtered = filtered.Where(r => r.ChannelName.Contains(channelFilter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(sourceRepoFilter))
+        {
+            filtered = filtered.Where(r =>
+                r.SourceRepository.Contains(sourceRepoFilter, StringComparison.OrdinalIgnoreCase) ||
+                ShortRepositoryName(r.SourceRepository).Contains(sourceRepoFilter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return filtered;
+    }
+
+    internal static string FormatSubscriptionHealth(string targetRepository, IReadOnlyList<SubscriptionHealthResult> results, bool compact = false)
+    {
         var sb = new StringBuilder();
         var staleCount = results.Count(r => r.IsStale);
         sb.AppendLine($"Subscription health for **{targetRepository}**: {results.Count} subscription(s), {staleCount} stale\n");
 
         foreach (var r in results)
         {
+            if (compact)
+            {
+                sb.AppendLine(FormatCompactSubscriptionHealthLine(r));
+                continue;
+            }
+
             string status;
             if (r.IsStale)
             {
@@ -214,7 +256,59 @@ public partial class MaestroMcpTools
             sb.AppendLine();
         }
 
-        return Timestamp(noCache) + sb.ToString();
+        return sb.ToString();
+    }
+
+    private static string FormatCompactSubscriptionHealthLine(SubscriptionHealthResult result)
+    {
+        var source = ShortRepositoryName(result.SourceRepository);
+        var status = result.IsStale
+            ? FormatCompactStaleStatus(result)
+            : "current";
+        var pr = CompactPrReference(result.TrackedPr?.PrUrl);
+        var prefix = result.Error != null ? "❌" : result.IsStale ? "⚠️" : "✅";
+        var error = result.Error != null ? $"; error: {result.Error}" : "";
+
+        return $"{prefix} {source} → {result.TargetBranch}: {status} (PR: {pr}{error})";
+    }
+
+    private static string CompactPrReference(string? prUrl)
+    {
+        if (string.IsNullOrWhiteSpace(prUrl))
+            return "none";
+
+        var trimmed = prUrl.Trim().TrimEnd('/');
+        var lastSegment = trimmed.Split('/').LastOrDefault();
+        return int.TryParse(lastSegment, out _) ? $"#{lastSegment}" : trimmed;
+    }
+
+    private static string FormatCompactStaleStatus(SubscriptionHealthResult result)
+    {
+        if (result.CommitsBehind.HasValue)
+            return $"{result.CommitsBehind.Value} commits behind";
+
+        return $"~{result.BuildsBehind} builds behind";
+    }
+
+    private static string ShortRepositoryName(string repository)
+    {
+        var trimmed = repository.Trim().TrimEnd('/');
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            trimmed = uri.AbsolutePath.Trim('/');
+        }
+
+        trimmed = trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase)
+            ? trimmed[..^4]
+            : trimmed;
+
+        var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length switch
+        {
+            >= 2 => string.Join('/', parts[^2..]),
+            1 => parts[0],
+            _ => repository
+        };
     }
     [McpServerTool(Name = "maestro_trigger_subscription", Title = "Trigger Subscription", Idempotent = true)]
     [Description("Trigger a Maestro subscription. Provide buildId directly, or provide sourceRepository and channelName to auto-resolve the latest build. Use force=true to force-trigger (overwrites existing PR branch) for stale backflow PR remediation.")]

--- a/src/MaestroTool.Tests/MaestroMcpTools/MaestroMcpToolsTests.cs
+++ b/src/MaestroTool.Tests/MaestroMcpTools/MaestroMcpToolsTests.cs
@@ -82,6 +82,7 @@ public class MaestroMcpToolsTests : IDisposable
         bool stale = false,
         int buildsBehind = 0,
         int? commitsBehind = null,
+        string? error = null,
         TrackedPrDiagnosis? trackedPr = null) =>
         new(
             Guid.NewGuid(),
@@ -95,6 +96,7 @@ public class MaestroMcpToolsTests : IDisposable
             new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero),
             stale ? 110 : 100,
             new DateTimeOffset(2026, 5, 2, 0, 0, 0, TimeSpan.Zero),
+            Error: error,
             CommitsBehind: commitsBehind,
             TrackedPr: trackedPr);
 
@@ -286,6 +288,23 @@ public class MaestroMcpToolsTests : IDisposable
     }
 
     [Fact]
+    public void FilterSubscriptionHealthResults_WithStaleOnly_IncludesErroredSubscriptions()
+    {
+        var results = new[]
+        {
+            CreateHealth(source: "https://github.com/dotnet/runtime", stale: false, error: "health check failed"),
+            CreateHealth(source: "https://github.com/dotnet/arcade", stale: false)
+        };
+
+        var filtered = MaestroMcpTools.FilterSubscriptionHealthResults(results, staleOnly: true).ToList();
+
+        var only = Assert.Single(filtered);
+        Assert.False(only.IsStale);
+        Assert.Equal("health check failed", only.Error);
+        Assert.Equal("https://github.com/dotnet/runtime", only.SourceRepository);
+    }
+
+    [Fact]
     public void FilterSubscriptionHealthResults_WithChannelAndSourceFilters_IsCaseInsensitive()
     {
         var results = new[]
@@ -327,6 +346,44 @@ public class MaestroMcpToolsTests : IDisposable
         Assert.Contains("✅ dotnet/arcade → release/10.0: current", output);
         Assert.DoesNotContain("Last Applied:", output);
         Assert.DoesNotContain("Latest Available:", output);
+    }
+
+    [Fact]
+    public void FormatSubscriptionHealth_WithCompact_RendersErroredSubscriptionsAsError()
+    {
+        var results = new[]
+        {
+            CreateHealth(source: "https://github.com/dotnet/runtime", stale: false, error: "health check failed")
+        };
+
+        var output = MaestroMcpTools.FormatSubscriptionHealth("https://github.com/dotnet/dotnet", results, compact: true);
+
+        Assert.Contains("❌ dotnet/runtime → main: error (PR: none; error: health check failed)", output);
+        Assert.DoesNotContain("dotnet/runtime → main: current", output);
+    }
+
+    [Fact]
+    public void ShortRepositoryName_WithGitHubUrl_ReturnsOwnerAndRepo()
+    {
+        var result = MaestroMcpTools.ShortRepositoryName("https://github.com/dotnet/runtime.git");
+
+        Assert.Equal("dotnet/runtime", result);
+    }
+
+    [Fact]
+    public void ShortRepositoryName_WithAzDoUrl_ReturnsOrgProjectAndRepo()
+    {
+        var result = MaestroMcpTools.ShortRepositoryName("https://dev.azure.com/dnceng/internal/_git/dotnet-runtime");
+
+        Assert.Equal("dnceng/internal/dotnet-runtime", result);
+    }
+
+    [Fact]
+    public void ShortRepositoryName_WithEdgeCaseRootUrl_ReturnsInput()
+    {
+        var result = MaestroMcpTools.ShortRepositoryName("https://example.com/");
+
+        Assert.Equal("https://example.com/", result);
     }
 
     [Fact]

--- a/src/MaestroTool.Tests/MaestroMcpTools/MaestroMcpToolsTests.cs
+++ b/src/MaestroTool.Tests/MaestroMcpTools/MaestroMcpToolsTests.cs
@@ -75,6 +75,29 @@ public class MaestroMcpToolsTests : IDisposable
         return sub;
     }
 
+    private static SubscriptionHealthResult CreateHealth(
+        string source = "https://github.com/dotnet/runtime",
+        string branch = "main",
+        string channel = ".NET 10.0.1xx SDK",
+        bool stale = false,
+        int buildsBehind = 0,
+        int? commitsBehind = null,
+        TrackedPrDiagnosis? trackedPr = null) =>
+        new(
+            Guid.NewGuid(),
+            source,
+            "https://github.com/dotnet/dotnet",
+            branch,
+            channel,
+            stale,
+            buildsBehind,
+            100,
+            new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero),
+            stale ? 110 : 100,
+            new DateTimeOffset(2026, 5, 2, 0, 0, 0, TimeSpan.Zero),
+            CommitsBehind: commitsBehind,
+            TrackedPr: trackedPr);
+
     // ================================================================
     // Channel name-or-ID resolution tests
     // ================================================================
@@ -244,6 +267,79 @@ public class MaestroMcpToolsTests : IDisposable
         Assert.Contains(".NET 10.0.1xx SDK → 10", result);
         Assert.Contains("VS 17.14 → 20", result);
         Assert.DoesNotContain("- **", result);
+    }
+
+    [Fact]
+    public void FilterSubscriptionHealthResults_WithStaleOnly_OmitsHealthySubscriptions()
+    {
+        var results = new[]
+        {
+            CreateHealth(source: "https://github.com/dotnet/runtime", stale: true, buildsBehind: 5),
+            CreateHealth(source: "https://github.com/dotnet/arcade", stale: false)
+        };
+
+        var filtered = MaestroMcpTools.FilterSubscriptionHealthResults(results, staleOnly: true).ToList();
+
+        var only = Assert.Single(filtered);
+        Assert.True(only.IsStale);
+        Assert.Equal("https://github.com/dotnet/runtime", only.SourceRepository);
+    }
+
+    [Fact]
+    public void FilterSubscriptionHealthResults_WithChannelAndSourceFilters_IsCaseInsensitive()
+    {
+        var results = new[]
+        {
+            CreateHealth(source: "https://github.com/dotnet/runtime", channel: ".NET 10.0.1xx SDK", stale: true),
+            CreateHealth(source: "https://github.com/dotnet/aspnetcore", channel: ".NET 9.0.1xx SDK", stale: true),
+            CreateHealth(source: "https://github.com/dotnet/arcade", channel: ".NET 10.0.1xx SDK", stale: true)
+        };
+
+        var filtered = MaestroMcpTools.FilterSubscriptionHealthResults(
+            results,
+            channelFilter: "net 10",
+            sourceRepoFilter: "RUNTIME").ToList();
+
+        var only = Assert.Single(filtered);
+        Assert.Equal("https://github.com/dotnet/runtime", only.SourceRepository);
+    }
+
+    [Fact]
+    public void FormatSubscriptionHealth_WithCompact_ReturnsOneLinePerSubscription()
+    {
+        var results = new[]
+        {
+            CreateHealth(
+                source: "https://github.com/dotnet/runtime",
+                branch: "main",
+                channel: ".NET 10.0.1xx SDK",
+                stale: true,
+                buildsBehind: 7,
+                commitsBehind: 42,
+                trackedPr: new TrackedPrDiagnosis(TrackedPrState.Active, "https://github.com/dotnet/dotnet/pull/123", null)),
+            CreateHealth(source: "https://github.com/dotnet/arcade", branch: "release/10.0", stale: false)
+        };
+
+        var output = MaestroMcpTools.FormatSubscriptionHealth("https://github.com/dotnet/dotnet", results, compact: true);
+
+        Assert.Contains("Subscription health for **https://github.com/dotnet/dotnet**: 2 subscription(s), 1 stale", output);
+        Assert.Contains("⚠️ dotnet/runtime → main: 42 commits behind (PR: #123)", output);
+        Assert.Contains("✅ dotnet/arcade → release/10.0: current", output);
+        Assert.DoesNotContain("Last Applied:", output);
+        Assert.DoesNotContain("Latest Available:", output);
+    }
+
+    [Fact]
+    public void FormatSubscriptionHealth_WithDetailedMode_PreservesMultiLineBlocks()
+    {
+        var results = new[] { CreateHealth(source: "https://github.com/dotnet/runtime", stale: true, buildsBehind: 3) };
+
+        var output = MaestroMcpTools.FormatSubscriptionHealth("https://github.com/dotnet/dotnet", results);
+
+        Assert.Contains("**https://github.com/dotnet/runtime** → main", output);
+        Assert.Contains("Channel: .NET 10.0.1xx SDK | Status: ⚠️ STALE (~3 builds behind)", output);
+        Assert.Contains("Last Applied: #100", output);
+        Assert.Contains("Latest Available: #110", output);
     }
 
     // ================================================================


### PR DESCRIPTION
## Summary
- add staleOnly, channelFilter, sourceRepoFilter, and compact to maestro_subscription_health
- keep filters after the parallel health fan-out and preserve no-arg detailed output
- extract filter/formatter helpers and add direct tests
- update Naomi history, decision inbox, and mcp-tool-filtering skill confidence/examples

## Validation
- dotnet test --no-restore --nologo (188 passed; one earlier cache expiry timing failure passed on rerun)
- live dotnet/dotnet measurement: detailed 24,398 bytes; staleOnly+compact 3,049 bytes for 93 subscriptions / 43 stale

Stacked on PR #22 because that channel-filter branch is still the current base for this pattern.