### PR TITLE
refactor: trim MCP tool descriptions

### DIFF
--- a/.squad/agents/naomi/history.md
+++ b/.squad/agents/naomi/history.md
@@ -19,6 +19,11 @@
 
 ## Learnings
 
+### 2026-06-11: MCP tool-description economy
+
+- Tool descriptions are always-loaded routing context: lead with a verb, keep them to 1–2 sentences, and let parameter `[Description]` attributes carry formats, defaults, valid values, and filter behavior.
+- Adding filters tempts re-explaining them in the tool description; resist that growth vector by moving filter semantics to parameter descriptions and keeping only brief cross-routing hints on the tool.
+
 ### 2026-05-22: PR #24 review fixes — filter-miss UX and CLI validation
 
 - Empty-after-filter results should distinguish backend emptiness from filter misses; when unfiltered data exists but `staleOnly`/`channelFilter`/`sourceRepoFilter` remove everything, echo the applied filters in the response.

--- a/.squad/decisions/inbox/naomi-desc-trim-result.md
+++ b/.squad/decisions/inbox/naomi-desc-trim-result.md
@@ -1,0 +1,28 @@
+# Naomi MCP Description Trim Result
+
+**Author:** Naomi  
+**Date:** 2026-06-11  
+**Status:** Complete  
+**Input:** `.squad/decisions/inbox/holden-mcp-description-audit.md`
+
+## Achieved vs Projected
+
+Holden projected trimming tool descriptions from ~430 words / ~559 tokens to ~280 words / ~364 tokens, saving ~150 words / ~195 tokens.
+
+Measured on the current source tree:
+
+| File | Before words | After words | Word savings | Before tokens | After tokens | Token savings |
+|---|---:|---:|---:|---:|---:|---:|
+| `MaestroMcpTools.Builds.cs` | 76 | 61 | 15 | 99 | 79 | 20 |
+| `MaestroMcpTools.Channels.cs` | 60 | 40 | 20 | 78 | 52 | 26 |
+| `MaestroMcpTools.Codeflow.cs` | 116 | 76 | 40 | 151 | 99 | 52 |
+| `MaestroMcpTools.Subscriptions.cs` | 136 | 59 | 77 | 177 | 77 | 100 |
+| `MaestroMcpTools.Utilities.cs` | 25 | 15 | 10 | 32 | 20 | 12 |
+| **Total** | **413** | **251** | **162** | **537** | **327** | **211** |
+
+## Notes
+
+- Achieved savings slightly exceed projection: ~211 tokens saved vs ~195 projected.
+- Applied Holden's explicit rewrites for top offenders and used the same rules for remaining trim verdicts.
+- Added the flagged cross-routing hints for daily update, codeflow PRs, backflow status, and build freshness while still reducing total context.
+- This was a mechanical application of the established audit, not a new design decision.

--- a/.squad/skills/mcp-tool-description-economy/SKILL.md
+++ b/.squad/skills/mcp-tool-description-economy/SKILL.md
@@ -1,0 +1,36 @@
+# MCP Tool Description Economy
+
+**Confidence:** Medium (validated by independent full-sweep trim application)  
+**Source:** Holden audit 2026-06-11, helix.mcp reference pattern
+
+## Pattern
+
+MCP tool `[Description]` attributes are **always-loaded context** — every agent pays this cost upfront even if it only uses 1–3 tools. Parameter descriptions are only loaded when the agent is *considering* a tool.
+
+### What belongs in tool descriptions
+- **Purpose verb** — lead with what the tool does ("List...", "Get...", "Check...")
+- **Brief routing signal** — 1 phrase max ("Niche — only works for X", "Does NOT return Y — use Z")
+- **Tool cross-references** — when two tools are commonly confused ("For batch checks, use X instead")
+- **Target: 10–16 words / 1–2 sentences**
+
+### What does NOT belong in tool descriptions
+- **Parameter names or behaviors** — "staleOnly filters to stale subscriptions" → move to the `staleOnly` param `[Description]`
+- **Return-value schemas** — "Shows forward flow, backflow statuses, active PRs, and build staleness" → agent discovers this from output
+- **Implementation details** — "resolving aka.ms redirect URLs and checking Last-Modified header" → irrelevant for tool selection
+- **Domain knowledge** — "for stale backflow PR remediation" → belongs in knowledge tool or SKILL.md
+- **Default value explanations** — "Defaults to a 3-day window and skips expensive build-time metrics" → param description
+
+### Growth vector to watch
+Feature PRs that add parameters (filters, output modes) naturally expand tool descriptions. The anti-pattern is: "I added `compact` param, so I explain what compact does in the description." Instead: put the explanation on the param's `[Description]` and leave the tool description alone.
+
+## Checklist for PR review
+- [ ] Tool description ≤16 words?
+- [ ] Leads with a verb?
+- [ ] No parameter names mentioned in description?
+- [ ] No return-value shape described?
+- [ ] No implementation details?
+- [ ] Cross-refs only for commonly confused tool pairs?
+
+## Reference
+- helix.mcp trimmed 17 descriptions from ~60 → ~20 words average, removing ~550 words of always-loaded context
+- maestro.mcp March P0 cleanup was effective but growth crept back in PRs #22–#24

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Builds.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Builds.cs
@@ -81,7 +81,7 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_build_freshness", Title = "Build Freshness", ReadOnly = true, Idempotent = true)]
-    [Description("Check build freshness for a channel by resolving aka.ms redirect URLs and checking the Last-Modified header of the published build artifacts.")]
+    [Description("Check build freshness for a channel via aka.ms artifact age. Niche — only works for aka.ms channels.")]
     public async Task<string> GetBuildFreshness(
         [Description("Channel short name for aka.ms URL (e.g. '10.0.1xx', '9.0.1xx')")] string channel,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
@@ -110,7 +110,7 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_build_graph", Title = "Build Graph", ReadOnly = true, Idempotent = true)]
-    [Description("Get the full dependency graph for a build. Returns all builds in the dependency tree with their relationships.")]
+    [Description("Get the full dependency graph for a build.")]
     public async Task<string> GetBuildGraph(
         [Description("The BAR build ID to get the dependency graph for")] int buildId,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Channels.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Channels.cs
@@ -51,7 +51,7 @@ public partial class MaestroMcpTools
     }
 
     [McpServerTool(Name = "maestro_channels", Title = "List Channels", ReadOnly = true, Idempotent = true)]
-    [Description("List Maestro channels. Optional filter does a case-insensitive substring match on channel name (e.g. '.NET 10', 'VS 17.', 'Aspire'); classification is passed to Maestro; compact returns 'name → id' lines.")]
+    [Description("List Maestro channels, optionally filtered by name substring or classification.")]
     public async Task<string> GetChannels(
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
         [Description("Optional case-insensitive substring filter for channel names (e.g. '.NET 10', 'VS 17.', 'Aspire')")] string? filter = null,

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Codeflow.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Codeflow.cs
@@ -13,7 +13,7 @@ namespace MaestroTool.Core;
 public partial class MaestroMcpTools
 {
     [McpServerTool(Name = "maestro_trigger_daily_update", Title = "Trigger Daily Update", Idempotent = true)]
-    [Description("Trigger all daily-update subscriptions to run. This is a non-destructive action that initiates processing of all subscriptions configured for daily updates.")]
+    [Description("Trigger all daily-update subscriptions. Not for single subscriptions; use maestro_trigger_subscription for targeted triggers.")]
     public async Task<string> TriggerDailyUpdate(CancellationToken cancellationToken = default)
     {
         var dedupKey = "action:trigger-daily-update";
@@ -37,7 +37,7 @@ public partial class MaestroMcpTools
         }
     }
     [McpServerTool(Name = "maestro_codeflow_prs", Title = "Codeflow PRs", ReadOnly = true, Idempotent = true)]
-    [Description("List active codeflow (tracked) pull requests managed by Maestro. Optionally filter by channel name.")]
+    [Description("List active codeflow PRs managed by Maestro. For per-mapping health status, use maestro_codeflow_statuses.")]
     public async Task<string> GetCodeflowPrs(
         [Description("Filter by channel name (e.g. '.NET 10.0.1xx SDK')")] string? channelName = null,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
@@ -121,7 +121,7 @@ public partial class MaestroMcpTools
         }
     }
     [McpServerTool(Name = "maestro_backflow_status", Title = "Backflow Status", ReadOnly = true, Idempotent = true)]
-    [Description("Get backflow status for a specific VMR build. Shows per-branch backflow status including commit distance and subscription details.")]
+    [Description("Get backflow status for a VMR build. Requires a VMR build ID; use maestro_builds to find one.")]
     public async Task<string> GetBackflowStatus(
         [Description("The VMR (dotnet/dotnet) BAR build ID to check backflow status for")] int vmrBuildId,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
@@ -162,7 +162,7 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_flow_graph", Title = "Flow Graph", ReadOnly = true, Idempotent = true)]
-    [Description("Get the dependency flow graph for a channel. Defaults to a 3-day window and skips expensive build-time metrics; set days/includeBuildTimes for expanded investigations.")]
+    [Description("Get the dependency flow graph for a channel.")]
     public async Task<string> GetFlowGraph(
         [Description("The channel ID to get the flow graph for")] int channelId,
         [Description("Number of days to include in the flow graph analysis (default: 3, max: 30)")] int days = 3,
@@ -271,7 +271,7 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_codeflow_statuses", Title = "Codeflow Statuses", ReadOnly = true, Idempotent = true)]
-    [Description("Get codeflow status for a repository and branch. Shows forward flow and backflow subscription statuses, active PRs, and build staleness for each mapping. Defaults to the VMR (dotnet/dotnet, main).")]
+    [Description("Get codeflow status for a repository and branch. Defaults to the VMR (dotnet/dotnet, main).")]
     public async Task<string> GetCodeflowStatuses(
         [Description("Repository URL (default: https://github.com/dotnet/dotnet)")] string repositoryUrl = "https://github.com/dotnet/dotnet",
         [Description("Branch name (default: main)")] string branch = "main",

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Subscriptions.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Subscriptions.cs
@@ -11,7 +11,7 @@ namespace MaestroTool.Core;
 public partial class MaestroMcpTools
 {
     [McpServerTool(Name = "maestro_subscriptions", Title = "List Subscriptions", ReadOnly = true, Idempotent = true)]
-    [Description("List Maestro subscriptions filtered by source/target repository and/or channel name. For health checks, use maestro_subscription_health. For details on a single subscription by ID, use maestro_subscription.")]
+    [Description("List Maestro subscriptions. For health checks, use maestro_subscription_health.")]
     public async Task<string> GetSubscriptions(
         [Description("Filter by source repository URL (e.g. https://github.com/dotnet/runtime)")] string? sourceRepository = null,
         [Description("Filter by target repository URL (e.g. https://github.com/dotnet/dotnet)")] string? targetRepository = null,
@@ -48,7 +48,7 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_subscription", Title = "Get Subscription", ReadOnly = true, Idempotent = true)]
-    [Description("Get a specific Maestro subscription by its GUID ID, including health diagnostic comparing last applied build to latest available. For batch health checks across a repository, use maestro_subscription_health instead.")]
+    [Description("Get a specific Maestro subscription by ID with health diagnostic. For batch health checks, use maestro_subscription_health.")]
     public async Task<string> GetSubscription(
         [Description("The subscription GUID")] string subscriptionId,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
@@ -97,7 +97,7 @@ public partial class MaestroMcpTools
         return Timestamp(noCache) + sb.ToString();
     }
     [McpServerTool(Name = "maestro_subscription_health", Title = "Subscription Health", ReadOnly = true, Idempotent = true)]
-    [Description("Check subscription health for a target repository. Optional staleOnly includes stale or errored subscriptions; channelFilter and sourceRepoFilter do case-insensitive substring matching after cached health checks; compact returns one line per subscription.")]
+    [Description("Check subscription health for a target repository. For a single subscription, use maestro_subscription.")]
     public async Task<string> GetSubscriptionHealth(
         [Description("Target repository URL (e.g. https://github.com/dotnet/dotnet)")] string targetRepository,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,
@@ -328,7 +328,7 @@ public partial class MaestroMcpTools
         };
     }
     [McpServerTool(Name = "maestro_trigger_subscription", Title = "Trigger Subscription", Idempotent = true)]
-    [Description("Trigger a Maestro subscription. Provide buildId directly, or provide sourceRepository and channelName to auto-resolve the latest build. Use force=true to force-trigger (overwrites existing PR branch) for stale backflow PR remediation.")]
+    [Description("Trigger a Maestro subscription to process a build. Supports auto-resolving the latest build or force-triggering.")]
     public async Task<string> TriggerSubscription(
         [Description("The subscription GUID to trigger")] string subscriptionId,
         [Description("BAR build ID. If omitted, the latest build is resolved from sourceRepository and channelName.")] int? buildId = null,
@@ -396,7 +396,7 @@ public partial class MaestroMcpTools
         }
     }
     [McpServerTool(Name = "maestro_subscription_history", Title = "Subscription History", ReadOnly = true, Idempotent = true)]
-    [Description("Get the update history for a specific Maestro subscription. Shows timestamped actions, success/failure status, and error messages for failed updates.")]
+    [Description("Get update history for a Maestro subscription.")]
     public async Task<string> GetSubscriptionHistory(
         [Description("The subscription GUID")] string subscriptionId,
         [Description("Bypass cache and fetch fresh data")] bool noCache = false,

--- a/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Utilities.cs
+++ b/src/MaestroTool.Core/MaestroMcpTools/MaestroMcpTools.Utilities.cs
@@ -10,7 +10,7 @@ namespace MaestroTool.Core;
 public partial class MaestroMcpTools
 {
     [McpServerTool(Name = "maestro_clear_cache", Title = "Clear Cache", Destructive = true, Idempotent = true)]
-    [Description("Clear all cached Maestro data (shared across all mstro instances). Use after performing actions or when you need guaranteed fresh data from all tools.")]
+    [Description("Clear all cached Maestro data. Use when you need guaranteed fresh data from all tools.")]
     public string ClearCache()
     {
         _cache.Clear();


### PR DESCRIPTION
## Summary

Mechanical application of Holden's established audit in `.squad/decisions/inbox/holden-mcp-description-audit.md`; this is not a new tool-description design.

## Context savings

| File | Before words | After words | Before tokens | After tokens | Token savings |
|---|---:|---:|---:|---:|---:|
| `MaestroMcpTools.Builds.cs` | 76 | 61 | 99 | 79 | 20 |
| `MaestroMcpTools.Channels.cs` | 60 | 40 | 78 | 52 | 26 |
| `MaestroMcpTools.Codeflow.cs` | 116 | 76 | 151 | 99 | 52 |
| `MaestroMcpTools.Subscriptions.cs` | 136 | 59 | 177 | 77 | 100 |
| `MaestroMcpTools.Utilities.cs` | 25 | 15 | 32 | 20 | 12 |
| **Total** | **413** | **251** | **537** | **327** | **211** |

Token counts use Holden's ~1.3 tokens/word estimate. Achieved ~211 token savings vs ~195 projected.

## Verification

- `dotnet test --verbosity minimal` — 208/208 passed