### PR TITLE
release: v0.16.0

### DIFF
--- a/src/MaestroTool/MaestroTool.csproj
+++ b/src/MaestroTool/MaestroTool.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
     <ToolCommandName>mstro</ToolCommandName>
-    <Version>0.15.1</Version>
+    <Version>0.16.0</Version>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 


### PR DESCRIPTION
Release v0.16.0 — first minor bump since v0.15.1 (2026-04-22).

## What's new
- **Filters on `maestro_channels`** (#22): `filter`, `classification`, `compact`
- **Filters on `maestro_subscription_health`** (#23): `staleOnly`, `channelFilter`, `sourceRepoFilter`, `compact`. Output shrinks from ~24KB → ~3KB for dotnet/dotnet.
- **`maestro_flow_graph` perf defaults** (#19/#24): default window 7d → 3d, lazy build-time metrics, new `days` parameter (1–30), `timeoutSeconds` guard. Default invocations complete <30s on the previously-pathological graph.
- **subscription_health parallelization** (#20): GitHub fan-out via `Task.WhenAll` — typical multi-target check ~5s → ~1s.
- **MCP description trim** (#25): ~195 tokens of always-loaded context removed across 20 tool descriptions.

## Infrastructure
- Test SDK 17 → 18.5.1, all wildcard test packages pinned (#18)
- Sqlite 9 → 10, Extensions → 10.0.8, PCS Client beta refresh (#17)
- `RollForward Major` on MaestroTool executable (#16)
- GitHub Actions versions standardized + global.json SDK pinning (#15)

## Compatibility
- All new parameters are optional with backward-compatible defaults
- No breaking signature changes
- `maestro_flow_graph` default behavior changes (narrower scope) — callers wanting the old 7d window should pass `days: 7`

After this PR merges to master, tag `v0.16.0` to trigger NuGet publish via `publish.yml`.