### PR TITLE
harden: pin GitHub Actions to SHAs and enforce with zizmor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,19 +5,29 @@ on:
     tags:
       - 'v*'
 
+# Deny all by default; jobs opt in to exactly what they need.
+permissions: {}
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
+    name: Pack and publish to NuGet
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      id-token: write
-      contents: read
+      id-token: write # OIDC token for NuGet trusted publishing
+      contents: read # checkout the tagged commit
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '10.0.x'
 
@@ -30,9 +40,11 @@ jobs:
 
       - name: NuGet login (OIDC)
         id: login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Push to NuGet
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+        run: dotnet nuget push ./artifacts/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -8,14 +8,18 @@ on:
   push:
     branches: [dev, insider]
 
-permissions:
-  contents: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Build and test
         run: |

--- a/.github/workflows/squad-docs.yml
+++ b/.github/workflows/squad-docs.yml
@@ -9,16 +9,20 @@ on:
       - 'docs/**'
       - '.github/workflows/squad-docs.yml'
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   build:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false # Pages deploy uses OIDC, not git credentials
 
       - name: Build docs
         run: |

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -21,16 +21,20 @@ on:
   # Manual trigger
   workflow_dispatch:
 
-permissions:
-  issues: write
-  contents: read
-  pull-requests: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   heartbeat:
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check triage script
         id: check-script
@@ -53,7 +57,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -105,7 +109,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-insider-release.yml
+++ b/.github/workflows/squad-insider-release.yml
@@ -5,14 +5,16 @@ on:
   push:
     branches: [insider]
 
-permissions:
-  contents: write
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -4,20 +4,24 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
-  contents: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   assign-work:
     # Only trigger on squad:{member} labels (not the base "squad" label)
     if: startsWith(github.event.label.name, 'squad:')
+    permissions:
+      issues: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -116,7 +120,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -4,18 +4,22 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
-  contents: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   enforce:
+    permissions:
+      issues: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/squad-main-guard.yml
+++ b/.github/workflows/squad-main-guard.yml
@@ -5,18 +5,22 @@ on:
     branches: [main, preview]
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
-  pull-requests: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   guard:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check for forbidden paths
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // Fetch all files changed in this PR (paginated)

--- a/.github/workflows/squad-preview.yml
+++ b/.github/workflows/squad-preview.yml
@@ -5,14 +5,18 @@ on:
   push:
     branches: [preview]
 
-permissions:
-  contents: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   validate:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Build and test
         run: |

--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -10,15 +10,17 @@ on:
         type: choice
         options: ['false', 'true']
 
-permissions:
-  contents: write
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   dev-to-preview:
     name: Promote dev → preview
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,9 +70,11 @@ jobs:
   preview-to-main:
     name: Promote preview → main (release)
     needs: dev-to-preview
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -5,14 +5,16 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -4,19 +4,23 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
-  contents: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   triage:
     if: github.event.label.name == 'squad'
+    permissions:
+      issues: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -7,18 +7,22 @@ on:
       - '.ai-team/team.md'
   workflow_dispatch:
 
-permissions:
-  issues: write
-  contents: read
+# Deny all by default; each job opts into what it needs.
+permissions: {}
 
 jobs:
   sync-labels:
+    permissions:
+      issues: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,44 @@
+name: Zizmor GHA security audit
+
+on:
+  push:
+    branches: [main, dev, preview, insider]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/zizmor.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/zizmor.yml'
+  workflow_dispatch:
+
+# Deny all by default; the job opts into exactly what it needs.
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Audit workflows with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the repository
+      actions: read # read workflow metadata for online audits
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: 1.25.2 # pin the analyzer for reproducible audits
+          persona: regular
+          min-severity: low # fail on low+ findings; informational is advisory only
+          # Annotate the run directly instead of relying on GitHub Advanced Security.
+          advanced-security: false
+          annotations: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,21 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+# Hardening policy for GitHub Actions, enforced in CI by .github/workflows/zizmor.yml
+
+rules:
+  # Require every `uses:` reference to be pinned to a full commit SHA.
+  # This is the primary defense against supply-chain attacks that hijack
+  # mutable tags/branches (e.g. the tj-actions style compromises).
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin
+
+  # The release/promotion workflows below run `git push` / create releases and
+  # therefore legitimately need the checkout's credentials to persist. This is
+  # an accepted, reviewed risk rather than an oversight.
+  artipacked:
+    ignore:
+      - squad-promote.yml # git push origin preview/main
+      - squad-release.yml # release step pushes tags / creates releases
+      - squad-insider-release.yml # insider release step pushes tags / creates releases
+


### PR DESCRIPTION
## Why
There's an active supply-chain attack wave that hijacks **mutable GitHub Actions tags** (e.g. the tj-actions/reviewdog compromises). Every workflow in this repo referenced actions by mutable tag (`@v6`, `@v9`, …), leaving us exposed. Audited with [zizmor](https://github.com/zizmorcore/zizmor) v1.25.2.

## Changes
**Supply chain (primary fix)**
- Pin all 24 action `uses:` references to immutable commit SHAs with `# vX.Y.Z` comments.

**publish.yml (NuGet) — now zero findings**
- Deny-by-default top-level `permissions: {}`, scoped per-job permissions.
- `persist-credentials: false` on checkout.
- Move `NUGET_API_KEY` out of the `run:` template into `env:` (template-injection).
- Add `concurrency` + job name.

**squad-* workflows**
- Move workflow-wide `permissions` to per-job scope (excessive-permissions).
- `persist-credentials: false` on read-only checkouts (artipacked).
- Left credentials on genuine `git push`/release jobs (promote/release/insider-release), documented as reviewed exceptions.

**Durable enforcement (new)**
- `.github/workflows/zizmor.yml` — CI gate failing on low+ findings on any workflow change.
- `.github/zizmor.yml` — repo-wide **hash-pin** policy so future tag pins are rejected.

## Result
`zizmor` reports **no findings** under the CI configuration (4 documented exceptions). All YAML validated.

> Note: `squad-heartbeat.yml` is template-managed (`squad upgrade`) — same hardening should be applied to its source templates to avoid drift.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>