### PR TITLE
ci: add pin-check guard and Dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Wait a few days before adopting a new release so a compromised
+    # action version isn't pulled in the instant it's published.
+    cooldown:
+      default-days: 7
+    groups:
+      github-owned-actions:
+        patterns:
+          - "actions/*"
+          - "github/*"
+    # Third-party actions (e.g. NuGet/*, zizmorcore/*) are intentionally
+    # left ungrouped so each SHA bump gets its own reviewable PR.

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,0 +1,47 @@
+name: Action Pin Check
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [master, main]
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-pinned:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Ensure all action references are pinned to a 40-char commit SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r -d '' file; do
+            # Strip comments, then find `uses:` lines that reference a remote action.
+            while IFS= read -r line; do
+              ref="${line#*@}"          # everything after the first @
+              ref="${ref%% *}"          # drop trailing inline comment / whitespace
+              if [[ ! "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                echo "::error file=$file::Unpinned action reference (must be a 40-char commit SHA): ${line## }"
+                fail=1
+              fi
+            done < <(grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^.][^ ]+@' "$file" \
+                       | sed 's/#.*$//' \
+                       | grep -vE 'uses:[[:space:]]*\./' || true)
+          done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+
+          if [[ "$fail" -ne 0 ]]; then
+            echo ""
+            echo "Pin every action to a full commit SHA, e.g.:"
+            echo "  uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3"
+            exit 1
+          fi
+          echo "All action references in .github/workflows are SHA-pinned. ✅"


### PR DESCRIPTION
Follow-up to the zizmor hardening (#27). Adds the two remaining pieces already present in the sibling repos (`dotnet-replay`, `helix.mcp`):

- **`pin-check.yml`** — fails CI if any action reference is not pinned to a full 40-char commit SHA, preventing unpinned tags from regressing back in.
- **`dependabot.yml`** — weekly `github-actions` updates with a **7-day cooldown** so a freshly published (potentially compromised) version isn't adopted instantly. github-owned actions are grouped; third-party bumps (`NuGet/*`, `zizmorcore/*`) stay individually reviewable.

## Verification
- Local pin-check guard over all workflows: all pinned ✅
- `zizmor 1.25.2` (whole repo, matching the CI action): **No findings** ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>