### PR TITLE
build(deps): pin SQLitePCLRaw 3.x for CVE-2025-6965

### DIFF
--- a/src/MaestroTool.Core/MaestroTool.Core.csproj
+++ b/src/MaestroTool.Core/MaestroTool.Core.csproj
@@ -8,6 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <!--
+      Transitive pins for CVE-2025-6965 / GHSA-2m69-gcr7-jv3q (high).
+      Microsoft.Data.Sqlite 10.0.8 still pulls SQLitePCLRaw.lib.e_sqlite3 2.1.x,
+      which has no backported fix; the patch shipped only in SQLitePCLRaw 3.x.
+      TODO: remove these pins once Microsoft.Data.Sqlite ships with SQLitePCLRaw 3.x natively.
+    -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="Microsoft.DotNet.ProductConstructionService.Client" Version="1.1.0-beta.26271.2" />
     <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Fixes **CVE-2025-6965** / **GHSA-2m69-gcr7-jv3q** (high severity) by pinning the SQLitePCLRaw package set to 3.x, which ships the patched native SQLite binary.

Mirrors [lewing/helix.mcp#80](https://github.com/lewing/helix.mcp/pull/80).

## Background

- `Microsoft.Data.Sqlite 10.0.8` still transitively pulls `SQLitePCLRaw.lib.e_sqlite3 2.1.x`.
- That package is flagged high-severity by [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) for *all* versions `<= 2.1.11`.
- The fix shipped in the SQLitePCLRaw 3.x line (`lib.e_sqlite3 3.50.3`, `core/bundle/provider 3.0.3`) — no 2.x backport (`first_patched_version: null` on the advisory).
- `Microsoft.Data.Sqlite` hasn't yet bumped its transitive reference.

## Change

Adds transitive pins in `MaestroTool.Core.csproj` (the only project that uses `Microsoft.Data.Sqlite`). This repo does not use Central Package Management, so pins live directly in the csproj.

| Package | Pin |
|---------|-----|
| `SQLitePCLRaw.bundle_e_sqlite3` | `3.0.3` |
| `SQLitePCLRaw.core` | `3.0.3` |
| `SQLitePCLRaw.provider.e_sqlite3` | `3.0.3` |
| `SQLitePCLRaw.lib.e_sqlite3` | `3.50.3` |

Inline comment references the CVE with a TODO to remove once `Microsoft.Data.Sqlite` ships with SQLitePCLRaw 3.x natively.

## Validation

- Solution builds with **0 warnings** (previously NU1903 on `lib.e_sqlite3` 2.1.x).
- **208 tests pass**, 0 failed — the SQLite-backed cache path exercises the SQLitePCLRaw 3.x ABI and works correctly.