### PR TITLE
build(deps): bump ModelContextProtocol 1.3.0 -> 1.4.0

### DIFF
--- a/src/MaestroTool.Core/MaestroTool.Core.csproj
+++ b/src/MaestroTool.Core/MaestroTool.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="Microsoft.DotNet.ProductConstructionService.Client" Version="1.1.0-beta.26271.2" />
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MaestroTool.Mcp/MaestroTool.Mcp.csproj
+++ b/src/MaestroTool.Mcp/MaestroTool.Mcp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MaestroTool.Core\MaestroTool.Core.csproj" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MaestroTool/MaestroTool.csproj
+++ b/src/MaestroTool/MaestroTool.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="ConsoleAppFramework" Version="5.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <ProjectReference Include="..\MaestroTool.Core\MaestroTool.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Bumps `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from `1.3.0` to [`1.4.0`](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v1.4.0) (released 2026-06-04). Picks up two security-hardening fixes that directly apply to this server.

## Why bump

### 🔐 Security hardening (auto-benefit)

| Fix | Affects us? |
|-----|-------------|
| Stdio transport no longer enumerates child-process env vars in Trace logs ([#1538](https://github.com/modelcontextprotocol/csharp-sdk/pull/1538)) | ✅ Yes — we use `WithStdioServerTransport()` in `MaestroTool/Program.cs` |
| Streamable HTTP `DELETE` on a session now validates the authenticated user matches the session owner ([#1604](https://github.com/modelcontextprotocol/csharp-sdk/pull/1604)) — mirrors the existing GET/POST check; returns `403` instead of terminating the session on a leaked `Mcp-Session-Id` | ✅ Yes — `MaestroTool.Mcp/Program.cs` calls `MapMcp()` |

### 🏢 New features (available, not adopted in this PR)

- `IdentityAssertionGrantProvider` (ID-JAG / [SEP-990](https://github.com/modelcontextprotocol/csharp-sdk/pull/1305)) — RFC 8693 + RFC 7523 token exchange for enterprise SSO. Useful later if we add managed auth.
- `InheritEnvironmentVariables` on `StdioClientTransportOptions` — client-side, not consumed here.

## API surface check

We only use:
- `[McpServerToolType]` / `[McpServerTool]` attributes (tool declarations across `MaestroMcpTools/*`)
- `WithStdioServerTransport()` (CLI)
- `MapMcp()` (AspNetCore Streamable HTTP)

All source-compatible across 1.3.0 → 1.4.0.

## Changes

| Project | From | To |
|---------|------|----|
| `MaestroTool.Core` | `ModelContextProtocol 1.3.0` | `1.4.0` |
| `MaestroTool.Mcp` | `ModelContextProtocol.AspNetCore 1.3.0` | `1.4.0` |
| `MaestroTool` | `ModelContextProtocol 1.3.0` | `1.4.0` |

## Validation

- Solution builds: **0 warnings, 0 errors**
- Tests: **208 passed**, 0 failed