### PR TITLE
release: v0.17.0

### DIFF
--- a/src/MaestroTool/MaestroTool.csproj
+++ b/src/MaestroTool/MaestroTool.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
     <ToolCommandName>mstro</ToolCommandName>
-    <Version>0.16.0</Version>
+    <Version>0.17.0</Version>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 


### PR DESCRIPTION
Release v0.17.0 — first minor bump since v0.16.0 (2026-05-22).

## What's new

### 🆕 `maestro_subscription_outcomes` MCP tool (#31)
Lists categorized subscription trigger outcomes from the new PCS `ISubscriptionTriggerOutcomes` API. Filterable by subscription, build, date range, and outcome type. Single-line, LLM-friendly output with emoji prefixes:
- ✅ Updated · ⏭️ NoUpdate · 🚫 NotUpdatable · ❌ Failure · ⚠️ UserError · 🔀 HasConflict · 🕒 Rescheduled

### 🩺 `maestro_subscription_health` surfaces `LatestOutcome` (#31)
For each stale subscription, the most recent trigger outcome (type + message) is rendered inline. Ground-truth diagnostic data from PCS replaces guesswork for *why* a subscription is stuck. Existing heuristics (oscillation, TrackedPrDiagnosis, GitHub compare) retained as a complement; a TODO flags them for future retirement once outcomes data is trusted across more sessions.

### 🔐 Security hardening
- **SQLitePCLRaw 3.x pin** (#29) — fixes CVE-2025-6965 / GHSA-2m69-gcr7-jv3q (high). `Microsoft.Data.Sqlite` still pulls SQLitePCLRaw 2.1.x transitively; we pin to 3.x where the fix shipped.
- **ModelContextProtocol SDK 1.4.0** (#30) — picks up two security fixes from the upstream SDK: stdio transport no longer logs env vars at Trace level, and Streamable HTTP DELETE now validates session ownership (returns 403 instead of accepting a leaked `Mcp-Session-Id`). Both apply to this server.

### 🛠 Infra
- **GitHub Actions SHA-pinning** (#27) enforced via zizmor in CI (#28).
- **Dependabot** for GitHub Actions added.

## Dependency bumps
| Package | From | To |
|---|---|---|
| `Microsoft.DotNet.ProductConstructionService.Client` | 1.1.0-beta.26271.2 | 1.1.0-beta.26324.1 |
| `ModelContextProtocol` / `.AspNetCore` | 1.3.0 | 1.4.0 |
| `Microsoft.Extensions.DependencyInjection` | 10.0.8 | 10.0.9 |
| `SQLitePCLRaw.bundle_e_sqlite3` / `.core` / `.provider.e_sqlite3` | (transitive 2.1.x) | 3.0.3 (explicit pin) |
| `SQLitePCLRaw.lib.e_sqlite3` | (transitive 2.1.11) | 3.50.3 (explicit pin) |

## After merge

Tag `v0.17.0` and push — `publish.yml` will pack and push to NuGet via OIDC trusted publishing.