### PR TITLE
release: v0.18.0

### DIFF
--- a/src/MaestroTool/MaestroTool.csproj
+++ b/src/MaestroTool/MaestroTool.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
     <ToolCommandName>mstro</ToolCommandName>
-    <Version>0.17.0</Version>
+    <Version>0.18.0</Version>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 


### PR DESCRIPTION
Release v0.18.0 — minor bump for the MCP UX hardening work shipped after v0.17.0.

## What's new

### 🛡️ MCP UX hardening (#34)

Three patterns adopted from sibling repo [lewing/helix.mcp](https://github.com/lewing/helix.mcp):

- **User-Agent identifier** — AzDO and GitHub clients now send `maestro.mcp/{version}` (informational version, semver) and an `X-Maestro-Mcp-Tool` header. Lets arcade-services and GitHub distinguish maestro.mcp traffic from generic SDK consumers.
- **Strict unknown-parameter rejection + did-you-mean** — `JsonUnmappedMemberHandling.Disallow` plus a `CallToolFilter` that catches misspelled/hallucinated params and returns structured "did you mean" hints (Levenshtein-based). Eliminates a class of silent zero-result bugs (e.g. `subscritpionId` typo gets caught instead of being silently dropped).
- **Progress notifications** — `maestro_subscription_health` (per-N completions with monotonic guard) and `maestro_flow_graph` (start + completion) now emit MCP progress events when the client supplies a `progressToken`. Auto-injected `IProgress<ProgressNotificationValue>` parameter; silent no-op when no token.

## Reliability fixes

The PR went through 5 rounds of Copilot-bot review. Notable correctness fixes that landed:

- Production race in subscription_health progress emission — `Interlocked.Increment` made `done` values monotonic but the subsequent `Report()` calls weren't ordered across parallel tasks. Now: `reportLock` + `lastReported` guard so out-of-order reports are dropped and the MCP client only observes strictly increasing progress.
- `ProgressReporter.ItemStep` integer-division bug — for totals like 15, step was 1 (emitted 15 updates instead of the documented ~10). Switched to ceiling division.
- All early-return paths on instrumented tools now emit a final 100% completion so client UIs can dismiss.
- Outcome formatter date rendering: `.ToUniversalTime()` before stamping `Z` suffix.
- Outcome filter `outcomeType` normalized to canonical casing (e.g. `"updated"` → `"Updated"`) before forwarding to PCS — fixes a silent zero-result bug.

## Tooling

- New `.squad/skills/mcp-strict-param-rejection/SKILL.md` and `.squad/skills/mcp-progress-notifications/SKILL.md` capture both patterns for future re-use.

## Dependency changes
None — all features built on the SDK and PCS versions shipped in v0.17.0.

## Validation
- Build: **0 warnings, 0 errors** (verified with `dotnet clean && dotnet build --no-incremental`)
- Tests: **246 passing**, 0 failed (+12 since v0.17.0 — 21 from #34 initial + 12 boundary tests for `ItemStep` and `SyncProgress`)
- Local `dotnet pack` produces `lewing.maestro.mcp.0.18.0.nupkg` cleanly

## After merge
Tag `v0.18.0` and push — `publish.yml` will pack and push to NuGet via OIDC trusted publishing.