### PR TITLE
build(deps): update MCP SDK to 2.2.0

### DIFF
--- a/src/MaestroTool.Core/MaestroTool.Core.csproj
+++ b/src/MaestroTool.Core/MaestroTool.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="Microsoft.DotNet.ProductConstructionService.Client" Version="1.1.0-beta.26324.1" />
-    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MaestroTool.Mcp/MaestroTool.Mcp.csproj
+++ b/src/MaestroTool.Mcp/MaestroTool.Mcp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MaestroTool.Core\MaestroTool.Core.csproj" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MaestroTool.Mcp/Program.cs
+++ b/src/MaestroTool.Mcp/Program.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using MaestroTool.Core;
+using ModelContextProtocol.AspNetCore;
 using ModelContextProtocol.Server;
 
 MaestroToolUserAgent.Initialize(Assembly.GetExecutingAssembly());
@@ -35,7 +36,10 @@ builder.Services
         options.AddBindingErrorFilter()
                .AddUnknownParameterFilter(typeof(MaestroMcpTools).Assembly);
     })
-    .WithHttpTransport()
+    .WithHttpTransport(options =>
+    {
+        options.SessionMode = HttpServerSessionMode.StatefulForInitializeClients;
+    })
     .WithToolsFromAssembly(typeof(MaestroMcpTools).Assembly, new System.Text.Json.JsonSerializerOptions
     {
         // Reject unknown parameters at binding time so callers get a structured error

--- a/src/MaestroTool/MaestroTool.csproj
+++ b/src/MaestroTool/MaestroTool.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="ConsoleAppFramework" Version="5.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
     <ProjectReference Include="..\MaestroTool.Core\MaestroTool.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- update `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from 1.4.0 to 2.2.0
- preserve stateful sessions for initialize-handshake clients
- serve clients using the 2026-07-28 protocol statelessly on the same HTTP endpoint

## Validation
- solution builds with 0 warnings and 0 errors
- all 246 tests pass
- Opus 5 self-review found no issues